### PR TITLE
Show event end time on schedule

### DIFF
--- a/core/src/main/java/com/advice/core/utils/TimeUtil.kt
+++ b/core/src/main/java/com/advice/core/utils/TimeUtil.kt
@@ -71,7 +71,7 @@ object TimeUtil {
         val pattern = if (is24HourFormat) {
             "HH:mm"
         } else {
-            "h:mm a"
+            "hh:mm"
         }
 
         val timeFormat = DateTimeFormatter.ofPattern(pattern)

--- a/ui/src/main/java/com/advice/ui/components/EventRowView.kt
+++ b/ui/src/main/java/com/advice/ui/components/EventRowView.kt
@@ -120,7 +120,7 @@ private fun CategoryDash(tags: List<Tag>) {
 @Composable
 private fun Time(time: String) {
     val parts = time.split(" - ")
-    val start = parts[0]
+    val begin = parts[0]
     val end = parts.getOrNull(1)
 
     Column(
@@ -128,7 +128,7 @@ private fun Time(time: String) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            start,
+            begin,
             textAlign = TextAlign.Center
         )
         if (end != null) {

--- a/ui/src/main/java/com/advice/ui/components/EventRowView.kt
+++ b/ui/src/main/java/com/advice/ui/components/EventRowView.kt
@@ -86,11 +86,7 @@ fun EventRowView(
             .fillMaxWidth()
     ) {
         CategoryDash(tags)
-        Text(
-            time.replace(" ", "\n"),
-            textAlign = TextAlign.Center,
-            modifier = Modifier.width(85.dp)
-        )
+        Time(time)
         Column(
             Modifier
                 .weight(1f)
@@ -118,6 +114,36 @@ private fun CategoryDash(tags: List<Tag>) {
                 .clip(RoundedCornerShape(4.dp))
                 .background(parseColor(tags.first().color))
         )
+    }
+}
+
+@Composable
+private fun Time(time: String) {
+    val parts = time.split(" - ")
+    val start = parts[0]
+    val end = parts.getOrNull(1)
+
+    Column(
+        Modifier.width(85.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            start,
+            textAlign = TextAlign.Center
+        )
+        if (end != null) {
+            Box(
+                Modifier
+                    .padding(vertical = 3.dp)
+                    .height(1.dp)
+                    .width(6.dp)
+                    .background(MaterialTheme.colorScheme.onSurface)
+            )
+            Text(
+                end,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 
@@ -168,7 +194,7 @@ private fun EventRowViewPreview() {
         Column {
             EventRowView(
                 title = "Compelled Decryption",
-                time = "5:30\nAM",
+                time = "5:30 AM - 7:00 AM",
                 location = "Track 1",
                 tags = listOf(
                     createTag(label = "Introduction", color = "#EEAAFF"),
@@ -179,10 +205,21 @@ private fun EventRowViewPreview() {
             )
             EventRowView(
                 title = "Compelled Decryption",
-                time = "6:00\nAM",
+                time = "6:00 AM - 8:00 AM",
                 location = "Track 1",
                 tags = listOf(
                     createTag(label = "Talk", color = "#FF61EEAA"),
+                    createTag(label = "Introduction", color = "#EEAAFF"),
+                ),
+                isBookmarked = false,
+                onEventPressed = {},
+                onBookmark = {},
+            )
+            EventRowView(
+                title = "Compelled Decryption",
+                time = "7:00 AM",
+                location = "Track 1",
+                tags = listOf(
                     createTag(label = "Introduction", color = "#EEAAFF"),
                 ),
                 isBookmarked = false,

--- a/ui/src/main/java/com/advice/ui/components/EventRowView.kt
+++ b/ui/src/main/java/com/advice/ui/components/EventRowView.kt
@@ -132,16 +132,10 @@ private fun Time(time: String) {
             textAlign = TextAlign.Center
         )
         if (end != null) {
-            Box(
-                Modifier
-                    .padding(vertical = 3.dp)
-                    .height(1.dp)
-                    .width(6.dp)
-                    .background(MaterialTheme.colorScheme.onSurface)
-            )
             Text(
                 end,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelSmall
             )
         }
     }
@@ -194,7 +188,7 @@ private fun EventRowViewPreview() {
         Column {
             EventRowView(
                 title = "Compelled Decryption",
-                time = "5:30 AM - 7:00 AM",
+                time = "05:30 - 07:00",
                 location = "Track 1",
                 tags = listOf(
                     createTag(label = "Introduction", color = "#EEAAFF"),
@@ -205,7 +199,7 @@ private fun EventRowViewPreview() {
             )
             EventRowView(
                 title = "Compelled Decryption",
-                time = "6:00 AM - 8:00 AM",
+                time = "06:00 - 08:00",
                 location = "Track 1",
                 tags = listOf(
                     createTag(label = "Talk", color = "#FF61EEAA"),
@@ -217,7 +211,7 @@ private fun EventRowViewPreview() {
             )
             EventRowView(
                 title = "Compelled Decryption",
-                time = "7:00 AM",
+                time = "07:00",
                 location = "Track 1",
                 tags = listOf(
                     createTag(label = "Introduction", color = "#EEAAFF"),

--- a/ui/src/main/java/com/advice/ui/screens/ScheduleScreen.kt
+++ b/ui/src/main/java/com/advice/ui/screens/ScheduleScreen.kt
@@ -212,7 +212,7 @@ private fun ScheduleScreenContent(
                         item(key = it.id) {
                             EventRowView(
                                 title = it.title,
-                                time = TimeUtil.getTimeStamp(context, it),
+                                time = TimeUtil.getEventTimeStamp(context, it),
                                 location = it.location.name,
                                 tags = it.types,
                                 isBookmarked = it.isBookmarked,


### PR DESCRIPTION
At DEF CON this year I found it inconvenient to have to click into an event to see when it ends. I wanted to prioritize events like talks that lasts around an hour, over events like CTFs that last all day which I can go check out later. This PR adds the end times of the events in schedule.

I have also made PRs for this feature for the web and iOS version: [PR for web](https://github.com/BeezleLabs/hackertracker-info/pull/1), [PR for iOS](https://github.com/BeezleLabs/hackertracker/pull/6).

It looks like this when I run it in the emulator:

|  light  |  dark  |
|---|---|
|![Screenshot_20230819_204418](https://github.com/Advice-Dog/Schedule/assets/8357970/87a24b11-ebc5-44ff-baa0-552e681043f3)|![Screenshot_20230819_204428](https://github.com/Advice-Dog/Schedule/assets/8357970/25654db3-e744-4ad8-9f59-4dec5f17df0c)|
